### PR TITLE
These changes fixes Vault Chest sizes.

### DIFF
--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestGeneratedLootAmount.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestGeneratedLootAmount.java
@@ -1,0 +1,36 @@
+//
+// Created by BONNe
+// Copyright - 2025
+//
+
+
+package xyz.iwolfking.unobtainium.mixin.the_vault.fixes;
+
+
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import iskallia.vault.block.entity.VaultChestTileEntity;
+import net.minecraft.world.Container;
+
+
+@Mixin(VaultChestTileEntity.class)
+public class FixVaultChestGeneratedLootAmount
+{
+    @Redirect(method = "fillLoot", at = @At(value = "FIELD", target = "Liskallia/vault/block/entity/VaultChestTileEntity;size:I", opcode = Opcodes.GETFIELD))
+    public int fixGeneratedLootSlots(VaultChestTileEntity instance)
+    {
+        // All generated vault chest inventories should be 27 items inside it.
+        return 27;
+    }
+
+
+    @Redirect(method = "getAvailableSlots", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/Container;getContainerSize()I"))
+    public int fixFilledSlots(Container instance)
+    {
+        // All generated vault chest inventories should be 27 items inside it.
+        return 27;
+    }
+}

--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestGeneratedLootAmount.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestGeneratedLootAmount.java
@@ -1,9 +1,3 @@
-//
-// Created by BONNe
-// Copyright - 2025
-//
-
-
 package xyz.iwolfking.unobtainium.mixin.the_vault.fixes;
 
 

--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestMenuSize.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestMenuSize.java
@@ -1,0 +1,109 @@
+//
+// Created by BONNe
+// Copyright - 2025
+//
+
+
+package xyz.iwolfking.unobtainium.mixin.the_vault.fixes;
+
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import iskallia.vault.block.VaultChestBlock;
+import iskallia.vault.block.entity.VaultChestTileEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.MenuProvider;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ChestMenu;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+
+
+@Mixin(VaultChestBlock.class)
+public class FixVaultChestMenuSize
+{
+    @Inject(method = "getMenuProvider", at = @At(value = "HEAD"), cancellable = true)
+    public void fixChestDisplaySize(BlockState state,
+        Level level,
+        BlockPos pos,
+        CallbackInfoReturnable<MenuProvider> cir)
+    {
+        // If chest is not Vault Chest, then it should open menu based on chest size.
+        // Otherwise it will open 27.
+
+        if (level.getBlockEntity(pos) instanceof VaultChestTileEntity chestEntity && !chestEntity.isVaultChest())
+        {
+            MenuProvider provider = new MenuProvider()
+            {
+                @Override
+                @NotNull
+                public Component getDisplayName()
+                {
+                    return chestEntity.getDisplayName();
+                }
+
+
+                @Override
+                @Nullable
+                public AbstractContainerMenu createMenu(int containerId,
+                    @NotNull Inventory playerInventory,
+                    @NotNull Player player)
+                {
+                    if (chestEntity.canOpen(player))
+                    {
+                        switch (chestEntity.getContainerSize())
+                        {
+                            case 36 ->
+                            {
+                                return new ChestMenu(MenuType.GENERIC_9x4,
+                                    containerId,
+                                    playerInventory,
+                                    chestEntity,
+                                    4);
+                            }
+                            case 45 ->
+                            {
+                                return new ChestMenu(MenuType.GENERIC_9x5,
+                                    containerId,
+                                    playerInventory,
+                                    chestEntity,
+                                    5);
+                            }
+                            case 54 ->
+                            {
+                                return new ChestMenu(MenuType.GENERIC_9x6,
+                                    containerId,
+                                    playerInventory,
+                                    chestEntity,
+                                    6);
+                            }
+                            default ->
+                            {
+                                return new ChestMenu(MenuType.GENERIC_9x3,
+                                    containerId,
+                                    playerInventory,
+                                    chestEntity,
+                                    3);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+            };
+            
+            cir.setReturnValue(provider);
+        }
+    }
+}

--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestMenuSize.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestMenuSize.java
@@ -1,9 +1,3 @@
-//
-// Created by BONNe
-// Copyright - 2025
-//
-
-
 package xyz.iwolfking.unobtainium.mixin.the_vault.fixes;
 
 

--- a/src/main/resources/unobtainium.mixins.json
+++ b/src/main/resources/unobtainium.mixins.json
@@ -11,6 +11,8 @@
     "the_vault.fixes.FixFireballLevelRadius",
     "the_vault.fixes.FixTotemsInRaidRooms",
     "the_vault.fixes.FixTrappedTreasureChests",
+    "the_vault.fixes.FixVaultChestGeneratedLootAmount",
+    "the_vault.fixes.FixVaultChestMenuSize",
     "the_vault.optimizations.OptimizeBlockBlacklist",
     "the_vault.optimizations.OptimizeGearSnapshots"
   ],


### PR DESCRIPTION
The FixVaultChestMenuSize mixin fixes issues where placed vault chests had the wrong menu.

The FixVaultChestGeneratedLootAmount is a brute force fix for generated vault chests having too large inventory.

