### PR TITLE
Fix step breaking

### DIFF
--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestStepBreaking.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestStepBreaking.java
@@ -26,16 +26,17 @@ public class FixVaultChestStepBreaking
         remap = false)
     private boolean fixOnDestroyedByPlayer(VaultChestBlock instance, @Local BlockEntity te)
     {
+        // Only Vault Chests (with loot data) should have step breaking
         return instance.hasStepBreaking() && te instanceof VaultChestTileEntity chest && chest.isVaultChest();
     }
 
 
     @Redirect(method = "playerDestroy",
         at = @At(value = "INVOKE",
-            target = "Liskallia/vault/block/VaultChestBlock;hasStepBreaking()Z"),
-        remap = false)
+            target = "Liskallia/vault/block/VaultChestBlock;hasStepBreaking()Z"))
     private boolean fixPlayerDestroy(VaultChestBlock instance, @Local(argsOnly = true) BlockEntity te)
     {
+        // Only Vault Chests (with loot data) should have step breaking
         return instance.hasStepBreaking() && te instanceof VaultChestTileEntity chest && chest.isVaultChest();
     }
 }

--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestStepBreaking.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestStepBreaking.java
@@ -1,0 +1,41 @@
+//
+// Created by BONNe
+// Copyright - 2025
+//
+
+
+package xyz.iwolfking.unobtainium.mixin.the_vault.fixes;
+
+
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import iskallia.vault.block.VaultChestBlock;
+import iskallia.vault.block.entity.VaultChestTileEntity;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+
+@Mixin(VaultChestBlock.class)
+public class FixVaultChestStepBreaking
+{
+    @Redirect(method = "onDestroyedByPlayer",
+        at = @At(value = "INVOKE",
+            target = "Liskallia/vault/block/VaultChestBlock;hasStepBreaking()Z"),
+        remap = false)
+    private boolean fixOnDestroyedByPlayer(VaultChestBlock instance, @Local BlockEntity te)
+    {
+        return instance.hasStepBreaking() && te instanceof VaultChestTileEntity chest && chest.isVaultChest();
+    }
+
+
+    @Redirect(method = "playerDestroy",
+        at = @At(value = "INVOKE",
+            target = "Liskallia/vault/block/VaultChestBlock;hasStepBreaking()Z"),
+        remap = false)
+    private boolean fixPlayerDestroy(VaultChestBlock instance, @Local(argsOnly = true) BlockEntity te)
+    {
+        return instance.hasStepBreaking() && te instanceof VaultChestTileEntity chest && chest.isVaultChest();
+    }
+}

--- a/src/main/resources/unobtainium.mixins.json
+++ b/src/main/resources/unobtainium.mixins.json
@@ -13,6 +13,7 @@
     "the_vault.fixes.FixTrappedTreasureChests",
     "the_vault.fixes.FixVaultChestGeneratedLootAmount",
     "the_vault.fixes.FixVaultChestMenuSize",
+    "the_vault.fixes.FixVaultChestStepBreaking",
     "the_vault.optimizations.OptimizeBlockBlacklist",
     "the_vault.optimizations.OptimizeGearSnapshots"
   ],


### PR DESCRIPTION
Vault Chests with step-breaking were not dropping their item if player placed chest.

That happened because breaking did not check the tag on the tile entity.