### PR TITLE
Add ability to add random jewel crafting recipe.

### DIFF
--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixRandomJewelCraftingRecipe.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixRandomJewelCraftingRecipe.java
@@ -1,0 +1,52 @@
+//
+// Created by BONNe
+// Copyright - 2025
+//
+
+
+package xyz.iwolfking.unobtainium.mixin.the_vault.fixes;
+
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+import iskallia.vault.VaultMod;
+import iskallia.vault.container.oversized.OverSizedItemStack;
+import iskallia.vault.core.random.JavaRandom;
+import iskallia.vault.gear.crafting.recipe.JewelCraftingRecipe;
+import iskallia.vault.item.gear.DataInitializationItem;
+import iskallia.vault.item.gear.DataTransferItem;
+import iskallia.vault.item.gear.VaultLevelItem;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+
+
+@Mixin(value = JewelCraftingRecipe.class, remap = false)
+public abstract class FixRandomJewelCraftingRecipe
+{
+    @Shadow
+    private ResourceLocation jewelAttribute;
+
+    @Inject(method = "createOutput", at = @At(value = "RETURN"), cancellable = true)
+    private void allowRandomJewelCrafting(List<OverSizedItemStack> consumed,
+        ServerPlayer crafter,
+        int vaultLevel,
+        CallbackInfoReturnable<ItemStack> cir)
+    {
+        // If attribute is empty, use random gear roller to get a jewel based on its loot table.
+        if (this.jewelAttribute.equals(VaultMod.id("empty")))
+        {
+            ItemStack stack = cir.getReturnValue();
+            VaultLevelItem.doInitializeVaultLoot(stack, vaultLevel);
+            stack = DataTransferItem.doConvertStack(stack, JavaRandom.ofNanoTime());
+            DataInitializationItem.doInitialize(stack, JavaRandom.ofNanoTime());
+            cir.setReturnValue(stack);
+        }
+    }
+}

--- a/src/main/resources/unobtainium.mixins.json
+++ b/src/main/resources/unobtainium.mixins.json
@@ -13,6 +13,7 @@
     "the_vault.fixes.FixInventoryBarrelFinder",
     "the_vault.fixes.FixJewelIdentificationOverwrite",
     "the_vault.fixes.FixJewelPouchStackSize",
+    "the_vault.fixes.FixRandomJewelCraftingRecipe",
     "the_vault.fixes.FixTotemsInRaidRooms",
     "the_vault.fixes.FixTrappedTreasureChests",
     "the_vault.fixes.FixVaultBarrelItemInsertRemove",


### PR DESCRIPTION
The jewel crafting table did not have ability to craft and identify random jewels anymore. This change fixes it. It allows to get a random jewel, if jewel attribute value in config is set to `the_vault:empty`. In that situation it will roll the jewel based on NBT data provided in output NBT.