### PR TITLE
Fixes Card Deck Sync issue.

### DIFF
--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixCardDeckSyncIssues.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixCardDeckSyncIssues.java
@@ -1,0 +1,65 @@
+//
+// Created by BONNe
+// Copyright - 2025
+//
+
+
+package xyz.iwolfking.unobtainium.mixin.the_vault.fixes;
+
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Map;
+
+import iskallia.vault.container.inventory.CardDeckContainer;
+import iskallia.vault.core.card.CardDeck;
+import iskallia.vault.core.card.CardPos;
+import iskallia.vault.item.CardItem;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.item.ItemStack;
+
+
+@Mixin(CardDeckContainer.class)
+public abstract class FixCardDeckSyncIssues extends SimpleContainer
+{
+    @Shadow(remap = false)
+    @Final
+    private CardDeck deck;
+
+
+    @Shadow(remap = false)
+    @Final
+    private Map<Integer, CardPos> slotMapping;
+
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void populateDeckCards(ItemStack delegate, CallbackInfo ci)
+    {
+        // They "optimize" decks to not store tags in inventory tag, but only as Card in data section.
+        // However, it was never used to populate card deck container, which caused all issues
+        // with sync and card disappearing.
+
+        for (CardPos pos : this.deck.getSlots())
+        {
+            int slot = pos.x + pos.y * 9;
+            this.slotMapping.put(slot, pos);
+
+            this.deck.getCard(pos).ifPresent(card ->
+            {
+                // Also funny but deck contains all cards always. That is due to the fact that
+                // CardItem#getCard that is used for updating deck container on setChanged always
+                // return Card instance, even if it is emtpy.
+                if (!card.getEntries().isEmpty())
+                {
+                    ItemStack cardItem = CardItem.create(card);
+                    this.setItem(slot, cardItem);
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultBarrelNestingTileEntity.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultBarrelNestingTileEntity.java
@@ -13,7 +13,7 @@ import net.minecraft.world.level.block.state.BlockState;
 
 
 @Mixin(VaultChestTileEntity.class)
-public abstract class FixesVaultBarrelNestingTileEntity implements Container
+public abstract class FixVaultBarrelNestingTileEntity implements Container
 {
     @Shadow
     public abstract BlockState getBlockState();

--- a/src/main/resources/unobtainium.mixins.json
+++ b/src/main/resources/unobtainium.mixins.json
@@ -7,8 +7,9 @@
   "plugin": "xyz.iwolfking.unobtainium.mixin.plugins.WoldMixinPlugin",
   "mixins": [
     "the_vault.fixes.FixAxesWithAnimalPen",
+    "the_vault.fixes.FixCardDeckSyncIssues",
     "the_vault.fixes.FixEmpoweredChaoticFocus",
-    "the_vault.fixes.FixesVaultBarrelNestingTileEntity",
+    "the_vault.fixes.FixVaultBarrelNestingTileEntity",
     "the_vault.fixes.FixFireballLevelRadius",
     "the_vault.fixes.FixInventoryBarrelFinder",
     "the_vault.fixes.FixJewelIdentificationOverwrite",


### PR DESCRIPTION
In between u15 and u16 card decks changed from `inventory` tag to `data` storing. However, this was not applied to deck container, which lead to issues where decks appeared empty, while they still contained cards.