### PR TITLE
Fixes oversized stacks voiding on inserting into barrels.

### DIFF
--- a/src/main/java/xyz/iwolfking/unobtainium/api/helper/ContainerItemHelper.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/api/helper/ContainerItemHelper.java
@@ -98,6 +98,13 @@ public class ContainerItemHelper {
         if (newStack.isEmpty() || !itemFilter.test(newStack)) return 0;
         SimpleContainer container = loadItemContainer(stack, blockEntityType, containerRows);
         ItemStack remainingStack = container.addItem(newStack);
+
+        // This simple loop allows to add as many items into container as there is space.
+        while (!remainingStack.isEmpty() && container.canAddItem(remainingStack))
+        {
+            remainingStack = container.addItem(remainingStack);
+        }
+
         return newStack.getCount() - remainingStack.getCount();
     }
 

--- a/src/main/java/xyz/iwolfking/unobtainium/api/lib/inventory/SimpleContainerWithSlots.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/api/lib/inventory/SimpleContainerWithSlots.java
@@ -1,5 +1,7 @@
 package xyz.iwolfking.unobtainium.api.lib.inventory;
 
+import org.jetbrains.annotations.NotNull;
+
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.world.SimpleContainer;
@@ -44,5 +46,27 @@ public class SimpleContainerWithSlots extends SimpleContainer {
         }
 
         return listtag;
+    }
+
+
+    @Override
+    public @NotNull ItemStack addItem(ItemStack itemStack)
+    {
+        // Prevents overstacked items to be inserted in single slot
+        if (itemStack.getCount() > itemStack.getMaxStackSize())
+        {
+            ItemStack copy = itemStack.copy();
+            copy.setCount(itemStack.getMaxStackSize());
+
+            // Try to insert normal stack size item
+            copy = super.addItem(copy);
+
+            // Reset remaining item stack size
+            itemStack.setCount(itemStack.getCount() - itemStack.getMaxStackSize() + copy.getCount());
+
+            return itemStack;
+        }
+
+        return super.addItem(itemStack);
     }
 }


### PR DESCRIPTION
All oversized stacks were voided by the easy shulker box code. I adjusted code so it works properly and does not void items on inserting.

The same situation happens with shulker-boxes, but due to missing dependency, I cannot fix that.