### PR TITLE
Revert changes made in 3e889c791ff92ded256c73ddb058b49d8df04749 commit

### DIFF
--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestGeneratedLootAmount.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultChestGeneratedLootAmount.java
@@ -1,31 +1,40 @@
 package xyz.iwolfking.unobtainium.mixin.the_vault.fixes;
 
 
-import iskallia.vault.init.ModBlocks;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 import iskallia.vault.block.entity.VaultChestTileEntity;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import iskallia.vault.init.ModBlocks;
+import iskallia.vault.init.ModItems;
+import net.minecraft.world.Container;
+import net.minecraft.world.level.block.state.BlockState;
 
 
-@Mixin(value = VaultChestTileEntity.class, remap = false)
-public class FixVaultChestGeneratedLootAmount {
-    @Inject(method = "getSize", at = @At("HEAD"), cancellable = true)
-    private void getSize(BlockState state, CallbackInfoReturnable<Integer> cir) {
-        Block block = state.getBlock();
-        if (block == ModBlocks.WOODEN_CHEST
-            || block == ModBlocks.LIVING_CHEST
-            || block == ModBlocks.ORNATE_CHEST
-            || block == ModBlocks.GILDED_CHEST
-            || block == ModBlocks.FLESH_CHEST
-            || block == ModBlocks.HARDENED_CHEST
-            || block == ModBlocks.ENIGMA_CHEST
-        ) {
-            cir.setReturnValue(27);
-        }
+/**
+ * This mixin fixes how chests are filled. DO NOT CHANGE IT WITHOUT REASON.
+ */
+@Mixin(value = VaultChestTileEntity.class)
+public abstract class FixVaultChestGeneratedLootAmount
+{
+    @Shadow public abstract BlockState getBlockState();
+
+
+    @Redirect(method = "fillLoot", at = @At(value = "FIELD", target = "Liskallia/vault/block/entity/VaultChestTileEntity;size:I", opcode = Opcodes.GETFIELD), remap = false)
+    public int fixGeneratedLootSlots(VaultChestTileEntity instance)
+    {
+        // All generated vault chest inventories should be 27 (54 for treasure chest) items inside it.
+        return instance.getBlockState().is(ModBlocks.TREASURE_CHEST) ? 54 : 27;
+    }
+
+
+    @Redirect(method = "getAvailableSlots", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/Container;getContainerSize()I"))
+    public int fixFilledSlots(Container instance)
+    {
+        // All generated vault chest inventories should be 27 items inside it.
+        return this.getBlockState().is(ModBlocks.TREASURE_CHEST) ? 54 : 27;
     }
 }


### PR DESCRIPTION
The issue was solved incorrectly and it broke all chest sizes. 

Add additional changes so it would work with treasure chests increased size.

Changing size of chests in general, will break all player-placed chests, as their size will be capped at 27. 

DO NOT CHANGE OUTPUT OF `getSize()` METHOD.