### PR TITLE
Small card and deck memory footprint optimization.

### DIFF
--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/optimizations/OptimizeCardDeckContainer.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/optimizations/OptimizeCardDeckContainer.java
@@ -1,0 +1,65 @@
+//
+// Created by BONNe
+// Copyright - 2025
+//
+
+
+package xyz.iwolfking.unobtainium.mixin.the_vault.optimizations;
+
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import iskallia.vault.container.inventory.CardDeckContainer;
+import iskallia.vault.core.card.Card;
+import iskallia.vault.item.CardItem;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+
+
+@Mixin(CardDeckContainer.class)
+public class OptimizeCardDeckContainer
+{
+    @Shadow(remap = false)
+    @Final
+    private ItemStack delegate;
+
+    @Redirect(method = "<init>",
+        at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/nbt/CompoundTag;contains(Ljava/lang/String;)Z"))
+    private boolean removeInventoryTag(CompoundTag instance, String inventory)
+    {
+        // Remove inventory tag. It should be there regardless, as getSharedTag removes "inventory"
+        // but just in case, remove it to avoid any possible issues with actual cards being added
+        // at the end.
+        instance.remove(inventory);
+        return false;
+    }
+
+
+    @Redirect(method = "setChanged",
+        at = @At(value = "INVOKE",
+            target = "Liskallia/vault/item/CardItem;getCard(Lnet/minecraft/world/item/ItemStack;)Liskallia/vault/core/card/Card;"),
+        remap = false)
+    private Card ignoreAirItems(ItemStack stack)
+    {
+        // This will reduce memory consumption of decks, as will allow empty decks to be emtpy.
+        return stack.isEmpty() ? null : CardItem.getCard(stack);
+    }
+
+
+    @Inject(method = "setChanged",
+        at = @At(value = "INVOKE",
+            target = "Liskallia/vault/item/CardDeckItem;setCardDeck(Lnet/minecraft/world/item/ItemStack;Liskallia/vault/core/card/CardDeck;)V"),
+        remap = false)
+    private void removeInventoryTag(CallbackInfo ci)
+    {
+        // This tag is not used at all and is removed in other places. No need to save it.
+        this.delegate.getOrCreateTag().remove("inventory");
+    }
+}

--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/optimizations/OptimizeCardDecks.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/optimizations/OptimizeCardDecks.java
@@ -27,6 +27,7 @@ public class OptimizeCardDecks
         at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
     private Object fixNullNbtReading(Map instance, Object k, Object v, @Local(index = 4) CompoundTag entry)
     {
+        // for some reason the adapters were flipped. Position cannot be null, but cards can. 
         return instance.put(CardPos.ADAPTER.readNbt(entry.get("pos")).orElseThrow(),
             entry.contains("card") ? Card.ADAPTER.readNbt(entry.getCompound("card")).orElse(null) : null);
     }

--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/optimizations/OptimizeCardDecks.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/optimizations/OptimizeCardDecks.java
@@ -1,0 +1,33 @@
+//
+// Created by BONNe
+// Copyright - 2025
+//
+
+
+package xyz.iwolfking.unobtainium.mixin.the_vault.optimizations;
+
+
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Map;
+
+import iskallia.vault.core.card.Card;
+import iskallia.vault.core.card.CardDeck;
+import iskallia.vault.core.card.CardPos;
+import net.minecraft.nbt.CompoundTag;
+
+
+@Mixin(value = CardDeck.class, remap = false)
+public class OptimizeCardDecks
+{
+    @Redirect(method = "readNbt(Lnet/minecraft/nbt/CompoundTag;)V",
+        at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
+    private Object fixNullNbtReading(Map instance, Object k, Object v, @Local(index = 4) CompoundTag entry)
+    {
+        return instance.put(CardPos.ADAPTER.readNbt(entry.get("pos")).orElseThrow(),
+            entry.contains("card") ? Card.ADAPTER.readNbt(entry.getCompound("card")).orElse(null) : null);
+    }
+}

--- a/src/main/resources/unobtainium.mixins.json
+++ b/src/main/resources/unobtainium.mixins.json
@@ -6,8 +6,8 @@
   "refmap": "unobtainium.refmap.json",
   "plugin": "xyz.iwolfking.unobtainium.mixin.plugins.WoldMixinPlugin",
   "mixins": [
-    "the_vault.accessors.VaultChestTileEntityAccessor",
     "sophbackpacksvh.FixBackpackCME",
+    "the_vault.accessors.VaultChestTileEntityAccessor",
     "the_vault.fixes.FixAxesWithAnimalPen",
     "the_vault.fixes.FixCardDeckSyncIssues",
     "the_vault.fixes.FixEmpoweredChaoticFocus",
@@ -28,6 +28,8 @@
     "the_vault.fixes.FixVaultChestNames",
     "the_vault.fixes.FixVaultChestStepBreaking",
     "the_vault.optimizations.OptimizeBlockBlacklist",
+    "the_vault.optimizations.OptimizeCardDeckContainer",
+    "the_vault.optimizations.OptimizeCardDecks",
     "the_vault.optimizations.OptimizeCollectionQuest",
     "the_vault.optimizations.OptimizeGearSnapshots"
   ],


### PR DESCRIPTION
For some reason deck data stores a lot of empty cards. The code itself allows cards to be null, but updating cards for some reason used empty item stack to get cards, instead of returning null.