### PR TITLE
Fix timer start

### DIFF
--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultTimerStarting.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixVaultTimerStarting.java
@@ -1,0 +1,32 @@
+//
+// Created by BONNe
+// Copyright - 2025
+//
+
+
+package xyz.iwolfking.unobtainium.mixin.the_vault.fixes;
+
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import iskallia.vault.core.vault.player.Listener;
+
+
+/**
+ * By default, vault timer starts when player is 15 blocks from start position. However, default room
+ * from start point till exit is 15 blocks, which means that corners are outside 15 block range.
+ * This mixin changes that, and adds extra 5 blocks that should be enough for all impatient players
+ * that cannot sit on spot while waiting for other players.
+ */
+@Mixin(value = Listener.class, remap = false)
+public class FixVaultTimerStarting
+{
+    @ModifyConstant(method = "lambda$tickServer$0", constant = @Constant(doubleValue = 225.0f))
+    private static double fixRoomSize(double constant)
+    {
+        // Add extra 5 blocks before timer starts.
+        return 400;
+    }
+}

--- a/src/main/resources/unobtainium.mixins.json
+++ b/src/main/resources/unobtainium.mixins.json
@@ -27,6 +27,7 @@
     "the_vault.fixes.FixVaultChestMenuSize",
     "the_vault.fixes.FixVaultChestNames",
     "the_vault.fixes.FixVaultChestStepBreaking",
+    "the_vault.fixes.FixVaultTimerStarting",
     "the_vault.optimizations.OptimizeBlockBlacklist",
     "the_vault.optimizations.OptimizeCardDeckContainer",
     "the_vault.optimizations.OptimizeCardDecks",


### PR DESCRIPTION
By default, the vault timer starts when a player is 15 blocks from the start position. However, the default room from the start point to exit is 15 blocks, meaning corners are outside the 15-block range.
This mixin changes that and adds an extra 5 blocks which should be enough for all impatient players who cannot sit on the pot while waiting for other players.