### PR TITLE
Adds fixed dungeon barrel loot tables

### DIFF
--- a/src/main/resources/config_patches/palettes/dungeon_rooms/fix_gilded_chest_placeholder.json
+++ b/src/main/resources/config_patches/palettes/dungeon_rooms/fix_gilded_chest_placeholder.json
@@ -1,0 +1,92 @@
+{
+  "tile_processors": [
+    {
+      "type": "leveled",
+      "levels": [
+        {
+          "level": 0,
+          "type": "weighted_target",
+          "target": "the_vault:placeholder",
+          "output": {
+            "the_vault:placeholder{ Hidden: 1b }": 1
+          }
+        }
+      ]
+    },
+    {
+      "type": "placeholder",
+      "target": "WOODEN_CHEST",
+      "levels": [
+        {
+          "level": 0,
+          "probability": 0.6,
+          "success": {
+            "the_vault:gilded_barrel{LootTable:\"the_vault:dungeon/gilded_chest_lvl0\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 20,
+          "probability": 0.6,
+          "success": {
+            "the_vault:gilded_barrel{LootTable:\"the_vault:dungeon/gilded_chest_lvl20\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 50,
+          "probability": 0.6,
+          "success": {
+            "the_vault:gilded_barrel{LootTable:\"the_vault:dungeon/gilded_chest_lvl50\"}": 17,
+            "the_vault:gilded_barrel{LootTable:\"the_vault:dungeon/gilded_strongbox_lvl50\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 80,
+          "probability": 0.6,
+          "success": {
+            "the_vault:gilded_barrel{LootTable:\"the_vault:dungeon/gilded_chest_lvl50\"}": 9,
+            "the_vault:gilded_barrel{LootTable:\"the_vault:dungeon/gilded_strongbox_lvl50\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 100,
+          "probability": 0.6,
+          "success": {
+            "the_vault:gilded_barrel{LootTable:\"the_vault:dungeon/gilded_chest_lvl50\"}": 6,
+            "the_vault:gilded_barrel{LootTable:\"the_vault:dungeon/gilded_strongbox_lvl50\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        }
+      ]
+    },
+    {
+      "type": "placeholder",
+      "target": "COIN_STACKS",
+      "levels": [
+        {
+          "level": 0,
+          "probability": 1.0,
+          "success": {
+            "minecraft:air": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/config_patches/palettes/dungeon_rooms/fix_living_chest_placeholder.json
+++ b/src/main/resources/config_patches/palettes/dungeon_rooms/fix_living_chest_placeholder.json
@@ -1,0 +1,123 @@
+{
+  "tile_processors": [
+    {
+      "type": "leveled",
+      "levels": [
+        {
+          "level": 0,
+          "type": "weighted_target",
+          "target": "the_vault:placeholder",
+          "output": {
+            "the_vault:placeholder{ Hidden: 1b }": 1
+          }
+        }
+      ]
+    },
+    {
+      "type": "placeholder",
+      "target": "WOODEN_CHEST",
+      "levels": [
+        {
+          "level": 0,
+          "probability": 0.6,
+          "success": {
+            "the_vault:living_barrel{LootTable:\"the_vault:dungeon/living_chest_lvl0\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 10,
+          "probability": 0.6,
+          "success": {
+            "the_vault:living_barrel{LootTable:\"the_vault:dungeon/living_chest_lvl10\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 20,
+          "probability": 0.6,
+          "success": {
+            "the_vault:living_barrel{LootTable:\"the_vault:dungeon/living_chest_lvl20\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 30,
+          "probability": 0.6,
+          "success": {
+            "the_vault:living_barrel{LootTable:\"the_vault:dungeon/living_chest_lvl30\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 50,
+          "probability": 0.6,
+          "success": {
+            "the_vault:living_barrel{LootTable:\"the_vault:dungeon/living_chest_lvl50\"}": 17,
+            "the_vault:living_barrel{LootTable:\"the_vault:dungeon/living_strongbox_lvl50\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 70,
+          "probability": 0.6,
+          "success": {
+            "the_vault:living_barrel{LootTable:\"the_vault:dungeon/living_chest_lvl70\"}": 17,
+            "the_vault:living_barrel{LootTable:\"the_vault:dungeon/living_strongbox_lvl70\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 80,
+          "probability": 0.6,
+          "success": {
+            "the_vault:living_barrel{LootTable:\"the_vault:dungeon/living_chest_lvl70\"}": 9,
+            "the_vault:living_barrel{LootTable:\"the_vault:dungeon/living_strongbox_lvl70\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 100,
+          "probability": 0.6,
+          "success": {
+            "the_vault:living_barrel{LootTable:\"the_vault:dungeon/living_chest_lvl70\"}": 6,
+            "the_vault:living_barrel{LootTable:\"the_vault:dungeon/living_strongbox_lvl70\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        }
+      ]
+    },
+    {
+      "type": "placeholder",
+      "target": "COIN_STACKS",
+      "levels": [
+        {
+          "level": 0,
+          "probability": 1.0,
+          "success": {
+            "minecraft:air": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/config_patches/palettes/dungeon_rooms/fix_ornate_chest_placeholder.json
+++ b/src/main/resources/config_patches/palettes/dungeon_rooms/fix_ornate_chest_placeholder.json
@@ -1,0 +1,113 @@
+{
+  "tile_processors": [
+    {
+      "type": "leveled",
+      "levels": [
+        {
+          "level": 0,
+          "type": "weighted_target",
+          "target": "the_vault:placeholder",
+          "output": {
+            "the_vault:placeholder{ Hidden: 1b }": 1
+          }
+        }
+      ]
+    },
+    {
+      "type": "placeholder",
+      "target": "WOODEN_CHEST",
+      "levels": [
+        {
+          "level": 0,
+          "probability": 0.6,
+          "success": {
+            "the_vault:ornate_barrel{LootTable:\"the_vault:dungeon/ornate_chest_lvl0\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 20,
+          "probability": 0.6,
+          "success": {
+            "the_vault:ornate_barrel{LootTable:\"the_vault:dungeon/ornate_chest_lvl20\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 30,
+          "probability": 0.6,
+          "success": {
+            "the_vault:ornate_barrel{LootTable:\"the_vault:dungeon/ornate_chest_lvl30\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 50,
+          "probability": 0.6,
+          "success": {
+            "the_vault:ornate_barrel{LootTable:\"the_vault:dungeon/ornate_chest_lvl50\"}": 17,
+            "the_vault:ornate_barrel{LootTable:\"the_vault:dungeon/ornate_strongbox_lvl50\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 65,
+          "probability": 0.6,
+          "success": {
+            "the_vault:ornate_barrel{LootTable:\"the_vault:dungeon/ornate_chest_lvl65\"}": 17,
+            "the_vault:ornate_barrel{LootTable:\"the_vault:dungeon/ornate_strongbox_lvl65\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 80,
+          "probability": 0.6,
+          "success": {
+            "the_vault:ornate_barrel{LootTable:\"the_vault:dungeon/ornate_chest_lvl65\"}": 9,
+            "the_vault:ornate_barrel{LootTable:\"the_vault:dungeon/ornate_strongbox_lvl65\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        },
+        {
+          "level": 100,
+          "probability": 0.6,
+          "success": {
+            "the_vault:ornate_barrel{LootTable:\"the_vault:dungeon/ornate_chest_lvl65\"}": 6,
+            "the_vault:ornate_barrel{LootTable:\"the_vault:dungeon/ornate_strongbox_lvl65\"}": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        }
+      ]
+    },
+    {
+      "type": "placeholder",
+      "target": "COIN_STACKS",
+      "levels": [
+        {
+          "level": 0,
+          "probability": 1.0,
+          "success": {
+            "minecraft:air": 1
+          },
+          "failure": {
+            "minecraft:air": 1
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
@iwolfking I have no idea how to add them as replacements via VHAPI.

But these are the corrected palettes for vault dungeon barrels.