### PR TITLE
Fixes broken bingo tasks after server restart

### DIFF
--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixBingoTaskAttaching.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/fixes/FixBingoTaskAttaching.java
@@ -1,0 +1,62 @@
+//
+// Created by BONNe
+// Copyright - 2025
+//
+
+
+package xyz.iwolfking.unobtainium.mixin.the_vault.fixes;
+
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import iskallia.vault.task.BingoTask;
+import iskallia.vault.task.ConfiguredTask;
+import iskallia.vault.task.Task;
+import iskallia.vault.task.TaskContext;
+
+
+/**
+ * After server restart bingo tasks were weird. They were marked as completed, but counter still went up.
+ * The reason for it was simple: BingoTask object stores completed tasks in `settledTasks` array.
+ * This array was saved together with BingoTask object and populated on loading.
+ * However, when BingoObjective is initialized, it attaches all BingoTask children, regardless of their
+ * completion status.
+ * In situations when bingo task was completed, they were attached to vault, but BingoTask did not process them
+ * in BingoTask#onTick, and never detached them from vault.
+ * This mixin detaches all completed bingo tasks in BingoTask#onAttach after they were attached.
+ */
+@Mixin(value = BingoTask.class, remap = false)
+public abstract class FixBingoTaskAttaching extends ConfiguredTask<BingoTask.Config>
+{
+    @Shadow private boolean[] settledTasks;
+
+
+    @Shadow public abstract int getWidth();
+
+
+    @Shadow public abstract int getHeight();
+
+
+    @Shadow public abstract Task getChild(int index);
+
+
+    @Shadow protected abstract void onComplete(Task task, TaskContext context);
+
+
+    @Override
+    public void onAttach(TaskContext context)
+    {
+        super.onAttach(context);
+
+        // Detach all completed tasks if any of tasks are settled.
+        for(int index = 0; index < this.getWidth() * this.getHeight(); ++index) {
+            boolean settled = this.settledTasks[index];
+            if (settled) {
+                Task task = this.getChild(index);
+                this.onComplete(task, context);
+                task.onDetach();
+            }
+        }
+    }
+}

--- a/src/main/java/xyz/iwolfking/unobtainium/optimizations/ActiveCardTaskHelper.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/optimizations/ActiveCardTaskHelper.java
@@ -115,7 +115,7 @@ public class ActiveCardTaskHelper
      */
     private void processPartialAwards(UUID playerUUID, Vault vault)
     {
-        List<TaskEntry> taskEntries = this.entries.get(playerUUID);
+        List<TaskEntry> taskEntries = this.entries.getOrDefault(playerUUID, Collections.emptyList());
 
         if (taskEntries.isEmpty())
         {
@@ -182,7 +182,13 @@ public class ActiveCardTaskHelper
         CrateLootGeneratorAccessor lootAccessor = (CrateLootGeneratorAccessor) crateLootGenerator;
         List<ItemStack> additionalItems = lootAccessor.getAdditionalItems();
 
-        List<TaskEntry> taskEntries = this.entries.get(playerUUID);
+        List<TaskEntry> taskEntries = this.entries.getOrDefault(playerUUID, Collections.emptyList());
+
+        if (taskEntries.isEmpty())
+        {
+            // Nothing to process
+            return;
+        }
 
         taskEntries.removeIf(entry ->
         {

--- a/src/main/resources/unobtainium.mixins.json
+++ b/src/main/resources/unobtainium.mixins.json
@@ -10,6 +10,7 @@
     "the_vault.accessors.CrateLootGeneratorAccessor",
     "the_vault.accessors.VaultChestTileEntityAccessor",
     "the_vault.fixes.FixAxesWithAnimalPen",
+    "the_vault.fixes.FixBingoTaskAttaching",
     "the_vault.fixes.FixCardDeckSyncIssues",
     "the_vault.fixes.FixEmpoweredChaoticFocus",
     "the_vault.fixes.FixFireballLevelRadius",


### PR DESCRIPTION
The issue was that all bingo tasks were attached on vault startup, but it never checked if bingo task were completed.