### PR TITLE
fix server shutdown hang when anyone is in a vault

### DIFF
--- a/src/main/java/xyz/iwolfking/unobtainium/fixes/FixShutdown.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/fixes/FixShutdown.java
@@ -1,0 +1,14 @@
+package xyz.iwolfking.unobtainium.fixes;
+
+import net.minecraftforge.event.server.ServerStoppingEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import xyz.iwolfking.unobtainium.mixin.the_vault.VirtualWorldsAccessor;
+
+@Mod.EventBusSubscriber(modid = "unobtainium")
+public class FixShutdown {
+    @SubscribeEvent
+    public static void serverStopping(ServerStoppingEvent event) {
+        VirtualWorldsAccessor.getCONCURRENT_POOL().shutdown();
+    }
+}

--- a/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/VirtualWorldsAccessor.java
+++ b/src/main/java/xyz/iwolfking/unobtainium/mixin/the_vault/VirtualWorldsAccessor.java
@@ -1,0 +1,12 @@
+package xyz.iwolfking.unobtainium.mixin.the_vault;
+
+import iskallia.vault.core.world.threading.ThreadPool;
+import iskallia.vault.world.data.VirtualWorlds;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(VirtualWorlds.class)
+public interface VirtualWorldsAccessor {
+    @Accessor
+    static ThreadPool getCONCURRENT_POOL() {throw new UnsupportedOperationException();}
+}

--- a/src/main/resources/unobtainium.mixins.json
+++ b/src/main/resources/unobtainium.mixins.json
@@ -13,6 +13,7 @@
     "levelleakfixes.imp.MixinMusicRingManager",
     "levelleakfixes.powah.MixinCableNet",
     "quarryplus.MixinConfigCommand",
+    "the_vault.VirtualWorldsAccessor",
     "the_vault.accessors.VaultChestTileEntityAccessor",
     "the_vault.fixes.FixBingoTaskAttaching",
     "the_vault.fixes.FixEmpoweredChaoticFocus",


### PR DESCRIPTION
it can still take a bit to shutdown if a lot of chunks are being generated and the server can't keep up
(it took like 5s for the threadpool to shutdown when I was flying fast in spectator)